### PR TITLE
34 add box shadow

### DIFF
--- a/search/static/search/css/citation.css
+++ b/search/static/search/css/citation.css
@@ -12,9 +12,7 @@ ol {
     box-sizing: border-box;
     position: relative;
     outline: black solid 1px;
-    box-shadow: 2px 2px 5px 0px rgba(0,0,0,0.41);
-    -webkit-box-shadow: 2px 2px 5px 0px rgba(0,0,0,0.41);
-    -moz-box-shadow: 2px 2px 5px 0px rgba(0,0,0,0.41);
+    box-shadow: 2px 2px 5px 0px rgba(70,70,70,0.5);
     background: white;
     padding: 0.5em;
 }

--- a/search/static/search/css/results.css
+++ b/search/static/search/css/results.css
@@ -30,6 +30,7 @@
     max-width: 100%;
     height: auto;
     margin-bottom: .5em;
+    box-shadow: 2px 2px 5px 0px rgba(70,70,70,0.5);
 }
 
 .flag-citation-control {


### PR DESCRIPTION
# Changes Made

- Fixes #34 
- Adds box shadow around flag images.
- Also updates the citation disclosure to use the same box shadow styling.

# Testing

- [ ] Works cross browser
 - [ ] Chrome
   - [ ] Mobile
   - [ ] Desktop
 - [ ] Firefox
   - [ ] Mobile
   - [ ] Desktop
 - [ ] Edge
   - [ ] Desktop
- [ ] WAVE reports no issues
- [ ] ChromeVox can read and interact with the whole page
